### PR TITLE
Add missing agent template to gem package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,9 +83,12 @@ docker-compose.override.yml
 # Local KB knowledge IS version controlled (don't ignore)
 !skills/*/*.md
 
-# Aircan testing files
+# Aircana testing files
 hooks
 scripts
 skills
 agents
 spec_target*
+
+# But DO track template directories
+!lib/aircana/templates/agents/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aircana (4.0.0.rc6)
+    aircana (4.0.0.rc7)
       httparty (~> 0.21)
       reverse_markdown (~> 2.1)
       thor (~> 0.19.1)

--- a/lib/aircana/templates/agents/base_agent.erb
+++ b/lib/aircana/templates/agents/base_agent.erb
@@ -1,0 +1,8 @@
+---
+name: <%= agent_name %>
+description: <%= agent_description %>
+model: inherit
+color: <%= color %>
+---
+
+Use the skill "<%= skill_name %>" to learn your domain, then perform the requested task.

--- a/lib/aircana/version.rb
+++ b/lib/aircana/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aircana
-  VERSION = "4.0.0.rc6"
+  VERSION = "4.0.0.rc7"
 end


### PR DESCRIPTION
- Add lib/aircana/templates/agents/base_agent.erb to git
- Update .gitignore to not ignore template directories
- Bump version to 4.0.0.rc7

Fixes issue where agent generation was failing silently with 'No such file or directory' error because the template file was being ignored by .gitignore pattern.