### PR TITLE
Add 'nvim' to available editors list

### DIFF
--- a/lib/aircana/cli/commands/doctor_helpers.rb
+++ b/lib/aircana/cli/commands/doctor_helpers.rb
@@ -67,7 +67,7 @@ module Aircana
         end
 
         def find_available_editors
-          %w[code subl atom nano vim vi].select { |cmd| command_available?(cmd) }
+          %w[code subl atom nano nvim vim vi].select { |cmd| command_available?(cmd) }
         end
 
         def check_directory(path, description)


### PR DESCRIPTION
This is just a quick and simple solution to an issue I ran into where `nvim` or Neovim (my terminal editor of choice) was not supported.

Ideally, I think any `$EDITOR` value should be accepted though. I may push up a PR for that if I get a chance.