### PR TITLE
Fix content loss in Confluence macro stripping

### DIFF
--- a/lib/aircana/contexts/confluence_content.rb
+++ b/lib/aircana/contexts/confluence_content.rb
@@ -57,10 +57,20 @@ module Aircana
           %r{<ac:structured-macro[^>]*ac:name="warning"[^>]*>.*?<ac:rich-text-body>(.*?)</ac:rich-text-body>.*?</ac:structured-macro>}m, '<blockquote><strong>⚠️ Warning:</strong> \1</blockquote>'
         )
 
-        # Strip other structured macros but preserve rich text body content
-        # Uses negative lookahead to exclude code macros (which use plain-text-body, not rich-text-body)
+        # Remove toc macros outright: they have no rich-text-body of their own,
+        # so the generic strip-and-preserve step below can't match them and
+        # would otherwise span into an unrelated later macro's body, deleting
+        # everything in between.
         cleaned.gsub!(
-          %r{<ac:structured-macro(?![^>]*ac:name="code")[^>]*>.*?<ac:rich-text-body>(.*?)</ac:rich-text-body>.*?</ac:structured-macro>}m, '\1'
+          %r{<ac:structured-macro[^>]*ac:name="toc"[^>]*>.*?</ac:structured-macro>}m, ""
+        )
+
+        # Strip other structured macros but preserve rich text body content.
+        # The gaps around <ac:rich-text-body> are barred from crossing into
+        # another <ac:structured-macro> tag, so a macro without its own body
+        # (e.g. jira) fails this match instead of swallowing unrelated content.
+        cleaned.gsub!(
+          %r{<ac:structured-macro(?![^>]*ac:name="code")[^>]*>(?:(?!<ac:structured-macro).)*?<ac:rich-text-body>(.*?)</ac:rich-text-body>(?:(?!<ac:structured-macro).)*?</ac:structured-macro>}m, '\1'
         )
 
         # Remove any remaining Confluence-specific tags

--- a/spec/aircana/contexts/confluence_spec.rb
+++ b/spec/aircana/contexts/confluence_spec.rb
@@ -394,6 +394,57 @@ RSpec.describe Aircana::Contexts::Confluence do
       expect(result).to include("Content between code blocks - THIS MUST BE PRESERVED")
       expect(result).to include("After second code block")
     end
+
+    it "does not delete content between a toc macro and a later unrelated macro's rich-text-body" do
+      html = "<ac:structured-macro ac:name=\"toc\" ac:schema-version=\"1\">" \
+             '<ac:parameter ac:name="maxLevel">6</ac:parameter>' \
+             "</ac:structured-macro>" \
+             "<h1>Section Heading</h1>" \
+             "<h2>First Entry Heading</h2>" \
+             "<p>THIS HEADING AND PARAGRAPH MUST SURVIVE</p>" \
+             '<ac:structured-macro ac:name="expand" ac:schema-version="1">' \
+             '<ac:parameter ac:name="title">Unrelated later section</ac:parameter>' \
+             "<ac:rich-text-body><p>Unrelated expand content</p></ac:rich-text-body>" \
+             "</ac:structured-macro>"
+
+      result = confluence.send(:preprocess_confluence_macros, html)
+
+      expect(result).to include("<h1>Section Heading</h1>")
+      expect(result).to include("<h2>First Entry Heading</h2>")
+      expect(result).to include("THIS HEADING AND PARAGRAPH MUST SURVIVE")
+      expect(result).to include("Unrelated expand content")
+      expect(result).not_to include("ac:structured-macro")
+    end
+
+    it "does not delete content between a jira macro (no rich-text-body) and a later macro's body" do
+      html = '<ac:structured-macro ac:name="jira" ac:schema-version="1">' \
+             '<ac:parameter ac:name="key">PROJ-123</ac:parameter>' \
+             "</ac:structured-macro>" \
+             "<h2>Entry heading right after the jira macro</h2>" \
+             "<p>THIS CONTENT MUST SURVIVE TOO</p>" \
+             '<ac:structured-macro ac:name="info" ac:schema-version="1">' \
+             "<ac:rich-text-body><p>Unrelated info content</p></ac:rich-text-body>" \
+             "</ac:structured-macro>"
+
+      result = confluence.send(:preprocess_confluence_macros, html)
+
+      expect(result).to include("<h2>Entry heading right after the jira macro</h2>")
+      expect(result).to include("THIS CONTENT MUST SURVIVE TOO")
+      expect(result).to include("Unrelated info content")
+    end
+
+    it "still preserves a panel macro's own rich-text-body when it directly follows a toc macro" do
+      html = '<ac:structured-macro ac:name="toc" ac:schema-version="1">' \
+             '<ac:parameter ac:name="maxLevel">6</ac:parameter>' \
+             "</ac:structured-macro>" \
+             '<ac:structured-macro ac:name="panel" ac:schema-version="1">' \
+             "<ac:rich-text-body><p>Panel content right after toc</p></ac:rich-text-body>" \
+             "</ac:structured-macro>"
+
+      result = confluence.send(:preprocess_confluence_macros, html)
+
+      expect(result).to include("<blockquote><p>Panel content right after toc</p></blockquote>")
+    end
   end
 
   describe "checksum optimization" do


### PR DESCRIPTION
## Summary
`preprocess_confluence_macros` strips macros via regex, not a real parser. Macros without their own `rich-text-body` (`toc`, `jira`) let the strip-and-preserve step span into an unrelated later macro's body, silently deleting everything in between.

## Fix
Strip `toc` macros outright, and bar the generic strip step from crossing into another `<ac:structured-macro>` tag.