### PR TITLE
Release 5.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.7]
+
+### Fixed
+- Fixed content loss when stripping Confluence macros that have no rich text body
+  - Macros such as `toc` and `jira` have no `<ac:rich-text-body>` of their own
+  - The generic strip-and-preserve regex could span into a later, unrelated macro's body and delete everything in between
+  - `toc` macros are now removed outright, and the generic regex is barred from crossing another `<ac:structured-macro>` tag
+
+### Added
+- `nvim` is now recognized in the `aircana doctor` available editors list
+
 ## [5.2.6]
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aircana (5.2.3)
+    aircana (5.2.7)
       aws-sdk-bedrockruntime (~> 1.0)
       httparty (~> 0.21)
       reverse_markdown (~> 2.1)

--- a/lib/aircana/version.rb
+++ b/lib/aircana/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aircana
-  VERSION = "5.2.6"
+  VERSION = "5.2.7"
 end


### PR DESCRIPTION
Fix content loss when stripping Confluence macros that lack a rich text body (#76), and recognize nvim in the doctor editor list (#75).

Macros such as toc and jira have no <ac:rich-text-body> of their own, so the generic strip-and-preserve regex could span into a later, unrelated macro's body and delete everything between them. toc macros are now removed outright, and the generic regex is barred from crossing another <ac:structured-macro> tag.